### PR TITLE
updated the formatting that the cpf should be informed

### DIFF
--- a/libs/cpf.js
+++ b/libs/cpf.js
@@ -49,13 +49,11 @@ CPF.generate = (isFormat) => {
 };
 
 CPF.isValid = (number) => {
-  if (number.length !== 14) return false;
-
   let stripped = CPF.strip(number);
+  
+  if (stripped.length !== 11) return false;
 
   if (!stripped) return false;
-
-  if (stripped.length !== 11) return false;
 
   if (IGNORELIST.indexOf(stripped) >= 0) return false;
 


### PR DESCRIPTION
Removendo primeiramente os caracteres que não são números e validando se o tamanho é diferente de 11, permite que seja validado CPF com ou sem formatação, na minha aplicação tive que chamar o método format antes de validar.